### PR TITLE
do nothing if address does not exist

### DIFF
--- a/bluew/device.py
+++ b/bluew/device.py
@@ -12,6 +12,7 @@ by any EngineBluew when queried for devices.
 
 
 import bluew
+import logging
 from bluew.ppobj import PPObj
 
 
@@ -58,5 +59,6 @@ class Device(PPObj):  # pylint: disable=too-many-instance-attributes
                 mac = super().__getattribute__('address')
                 self = bluew.info(mac)  # noqa: F841
             except AttributeError as error:
+                logger = logging.getLogger(__name__)
                 logger.debug("Invalid device")
         return super().__getattribute__(item)

--- a/bluew/device.py
+++ b/bluew/device.py
@@ -54,6 +54,9 @@ class Device(PPObj):  # pylint: disable=too-many-instance-attributes
         # or thou shall dive in an infinite recursion as deep as thy stack.
         # SERIOUSLY: `self.attr` is just gonna call this method again.
         if item not in Device.attrs:
-            mac = super().__getattribute__('address')
-            self = bluew.info(mac)  # noqa: F841
+            try:
+                mac = super().__getattribute__('address')
+                self = bluew.info(mac)  # noqa: F841
+            except AttributeError as error:
+                logger.debug("Invalid device")
         return super().__getattribute__(item)


### PR DESCRIPTION
This is a fix for Issue #14 
Occasionally, devices with no attributes appear, but all "real" devices are detected anyways so I added some exception handling.
Works for me